### PR TITLE
Create new_issues_to_core_project_board.yml

### DIFF
--- a/.github/workflows/new_issues_to_core_project_board.yml
+++ b/.github/workflows/new_issues_to_core_project_board.yml
@@ -1,0 +1,18 @@
+---
+
+name: Auto Assign New Issues to Project
+
+"on":
+  issues:
+    types: [opened]
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Add new issues to Core Current Sprint project
+    steps:
+      - uses: alex-page/github-project-automation-plus@50502d399cbb98cefe7ce1f99f93f78c6756562e
+        with:
+          project: Core (Team Board)
+          column: Incoming to triage
+          repo-token: ${{ secrets.GH_NEW_CARD_TO_PROJECT }}


### PR DESCRIPTION
Add action to move any issues created in the repo to be shown on the core team board incoming to triage column so we can triage and prioritise accordingly.